### PR TITLE
Relax server regex in Parser

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -44,7 +44,7 @@ Parser.prototype._transform = function _transform(input, encoding, done) {
 
 var RE_NICK = /^([a-z][a-z0-9\-\[\]\\`^\{\}_]*)(?: |!|@)/i,
     RE_USER = /^([^ \r\n@]+)/,
-    RE_SERVER = /^((?:[a-z][a-z0-9-]*\.)*(?:[a-z][a-z0-9-]*))/i,
+    RE_SERVER = /^((?:[a-z0-9][a-z0-9-]*\.)*(?:[a-z][a-z0-9-]*))/i,
     RE_COMMAND = /^(\d{3}|[A-Z]+)/;
 
 Parser.prototype.parse = function parse(text, state) {


### PR DESCRIPTION
The `RE_SERVER` in the Parser follows [RFC 952](http://www.nic.mc/information/RFC/RFC952.txt), which is officially what the IRC protocol uses. However, modern users often have hostnames based on their IP (like `192-168-0-1.ip.isp.acme.com`) which causes the parser to throw an error.

Hostnames starting with digits should be allowed (not hyphens, though). A less strict regex is unlikely to cause problems with old IRC servers, but the stricter regex **definately** causes problems for users with such IPs.
