### PR TITLE
Bug fix for EOL separators in ircii on Linux

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -15,7 +15,7 @@ Parser.prototype._transform = function _transform(input, encoding, done) {
 
   this.buffer += input;
 
-  var parts = this.buffer.split(/\r\n/);
+  var parts = this.buffer.split(/[\r\n]+/);
 
   this.buffer = parts.pop();
 


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc1459 section 2.3.1 the message separators are ether CR or LF or any combination of them silently ignoring multiples. The fix alters the split regex to account for this (bug found using ircii client on Linux).
